### PR TITLE
Fix: "Show on sale first" should not exclude products lacking sale price meta

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -91,7 +91,7 @@ Yes you can! Join in on our [GitHub repository](https://github.com/skyverge/wooc
 == Changelog ==
 
 = 2025.nn.nn - version 2.11.0-dev.1 =
- * Fix - "Show on sale first" should include all products
+ * Fix - "Show on sale first" should not exclude products lacking sale price meta
  * Misc - Add support for WooCommerce 9.7
 
 = 2023.07.28 - version 2.10.0 =

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,7 @@ Yes you can! Join in on our [GitHub repository](https://github.com/skyverge/wooc
 == Changelog ==
 
 = 2025.nn.nn - version 2.11.0-dev.1 =
+ * Fix - "Show on sale first" should include all products
  * Misc - Add support for WooCommerce 9.7
 
 = 2023.07.28 - version 2.10.0 =

--- a/woocommerce-extra-product-sorting-options.php
+++ b/woocommerce-extra-product-sorting-options.php
@@ -73,9 +73,6 @@ class WC_Extra_Sorting_Options {
 		// add new product sorting arguments
 		add_filter( 'woocommerce_get_catalog_ordering_args', [ $this, 'add_new_shop_ordering_args' ] );
 
-		// on sale ordering meta query
-		add_filter('woocommerce_product_query_meta_query', [$this, 'addOnSaleOrderingArgs']);
-
 		// load translations
 		add_action( 'init', [ $this, 'load_translation' ] );
 
@@ -446,10 +443,12 @@ class WC_Extra_Sorting_Options {
 			break;
 
 			case 'on_sale_first':
-
 				// 'meta_key' for this orderby value is handled separately via 'meta_query'
 				// arguments set in the addOnSaleOrderingArgs() callback.
 				$sort_args['orderby']  = [ 'meta_value' => 'DESC', $fallback => $fallback_order ];
+
+				// on sale ordering meta query
+				add_filter('woocommerce_product_query_meta_query', [$this, 'addOnSaleOrderingArgs']);
 
 			break;
 		}
@@ -469,11 +468,7 @@ class WC_Extra_Sorting_Options {
 	 */
 	public function addOnSaleOrderingArgs($metaQuery) {
 
-		if ('on_sale_first' !== $this->getOrderByFromRequest() ) {
-			return $metaQuery;
-		}
-
-		$metaQuery[] = [
+		return $metaQuery[] = [
 			'relation' => 'OR',
 			[
 				'key' => '_sale_price',
@@ -494,8 +489,6 @@ class WC_Extra_Sorting_Options {
 				],
 			],
 		];
-
-		return $metaQuery;
 	}
 
 

--- a/woocommerce-extra-product-sorting-options.php
+++ b/woocommerce-extra-product-sorting-options.php
@@ -382,14 +382,7 @@ class WC_Extra_Sorting_Options {
 	*/
 	public function add_new_shop_ordering_args( $sort_args ) {
 
-		// If we have the orderby via URL, let's pass it in.
-		// This means we're on a shop / archive, so if we don't have it, use the default.
-		if ( isset( $_GET['orderby'] ) ) {
-			$orderby_value = wc_clean( $_GET['orderby'] );
-		} else {
-			/* WooCommerce core filter defined in wc-template-functions.php */
-			$orderby_value = (string) apply_filters( 'woocommerce_default_catalog_orderby', get_option( 'woocommerce_default_catalog_orderby', 'menu_order' ) );
-		}
+		$orderby_value = $this->getOrderByFromRequest();
 
 		// Since a shortcode can be used on a non-WC page, we won't have $_GET['orderby'].
 		// Grab it from the passed in sorting args instead for non-WC pages.
@@ -458,6 +451,26 @@ class WC_Extra_Sorting_Options {
 		}
 
 		return $sort_args;
+	}
+
+	/**
+	 * Gets the orderby value from the current request.
+	 *
+	 * @return string
+	 */
+	private function getOrderByFromRequest() : string
+	{
+
+		// If we have the orderby via URL, let's pass it in.
+		// This means we're on a shop / archive, so if we don't have it, use the default.
+		if ( isset( $_GET['orderby'] ) ) {
+			$orderby_value = wc_clean( $_GET['orderby'] );
+		} else {
+			/* WooCommerce core filter defined in wc-template-functions.php */
+			$orderby_value = (string) apply_filters( 'woocommerce_default_catalog_orderby', get_option( 'woocommerce_default_catalog_orderby', 'menu_order' ) );
+		}
+
+		return $orderby_value;
 	}
 
 


### PR DESCRIPTION
Release: #34
Issue: https://godaddy-corp.atlassian.net/browse/MWC-11280

## Summary

When using the "Show sale items first" ordering option, some products are being excluded from the query.

## Details

Due to limitations with simple ordering in `WP_Query`, we can't just set `meta_key` and `meta_value` values to manipulate the product order with sale items first like we can with some of the other ordering options. This is because simple ordering doesn't account for products that are _missing_ the `_sale_price` meta key entirely.

To ensure products aren't inadvertently excluded, we need to shift to using a meta query for "on sale first", which does account for products missing the meta key.

## QA

### Setup

1. Have at least one product with a sale price configured.
2. Enable the "On-sale First" product sorting option (Customizer > WooCommerce > Product Catalog)

### Steps

#### Confirming the bug

1. Switch to the `master` branch
2. On the FOS, navigate to the shop page
3. From the product sorting drop-down, select "Sort by latest"
4. Note the total number of products returned.
5. Back in the product sorting drop-down, select "Show sale items first"
    - [x] The total number of products returned is lower than the total noted in step 4
    
### Confirming the fix

1. Switch to the `mwc-11280` branch
2. On the FOS, navigate to the shop page
3. From the product sorting drop-down, select "Sort by latest"
4. Note the total number of products returned.
5. Back in the product sorting drop-down, select "Show sale items first"
    - [x] The total number of products returned matches the total noted in step 4